### PR TITLE
Add support for steamLoginSecure cookie

### DIFF
--- a/community/community.go
+++ b/community/community.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 )
 
-const cookiePath = "http://steamcommunity.com/"
+const cookiePath = "https://steamcommunity.com/"
 
-func SetCookies(client *http.Client, sessionId, steamLogin string) {
+func SetCookies(client *http.Client, sessionId, steamLogin, steamLoginSecure string) {
 	if client.Jar == nil {
 		client.Jar, _ = cookiejar.New(new(cookiejar.Options))
 	}
@@ -26,6 +26,10 @@ func SetCookies(client *http.Client, sessionId, steamLogin string) {
 		&http.Cookie{
 			Name:  "steamLogin",
 			Value: steamLogin,
+		},
+		&http.Cookie{
+			Name:  "steamLoginSecure",
+			Value: steamLoginSecure,
 		},
 	})
 }

--- a/trade/tradeapi/trade.go
+++ b/trade/tradeapi/trade.go
@@ -18,7 +18,7 @@ import (
 	"time"
 )
 
-const tradeUrl = "http://steamcommunity.com/trade/%d/"
+const tradeUrl = "https://steamcommunity.com/trade/%d/"
 
 type Trade struct {
 	client *http.Client
@@ -32,8 +32,8 @@ type Trade struct {
 	baseUrl   string
 }
 
-// Creates a new Trade based on the given cookies `sessionid` and `steamLogin` and the trade partner's Steam ID.
-func New(sessionId, steamLogin string, other steamid.SteamId) *Trade {
+// Creates a new Trade based on the given cookies `sessionid`, `steamLogin`, `steamLoginSecure` and the trade partner's Steam ID.
+func New(sessionId, steamLogin steamLoginSecure, string, other steamid.SteamId) *Trade {
 	client := new(http.Client)
 	client.Timeout = 10 * time.Second
 
@@ -44,7 +44,7 @@ func New(sessionId, steamLogin string, other steamid.SteamId) *Trade {
 		baseUrl:   fmt.Sprintf(tradeUrl, other),
 		Version:   1,
 	}
-	community.SetCookies(t.client, sessionId, steamLogin)
+	community.SetCookies(t.client, sessionId, steamLogin, steamLoginSecure)
 	return t
 }
 

--- a/tradeoffer/client.go
+++ b/tradeoffer/client.go
@@ -14,7 +14,7 @@ import (
 
 type APIKey string
 
-const apiUrl = "http://api.steampowered.com/IEconService/%s/v%d"
+const apiUrl = "https://api.steampowered.com/IEconService/%s/v%d"
 
 type Client struct {
 	client    *http.Client
@@ -22,13 +22,13 @@ type Client struct {
 	sessionId string
 }
 
-func NewClient(key APIKey, sessionId, steamLogin string) *Client {
+func NewClient(key APIKey, sessionId, steamLogin, steamLoginSecure string) *Client {
 	c := &Client{
 		new(http.Client),
 		key,
 		sessionId,
 	}
-	community.SetCookies(c.client, sessionId, steamLogin)
+	community.SetCookies(c.client, sessionId, steamLogin, steamLoginSecure)
 	return c
 }
 
@@ -81,7 +81,7 @@ func (c *Client) Cancel(id TradeOfferId) error {
 }
 
 func (c *Client) Accept(id TradeOfferId) error {
-	resp, err := c.client.PostForm(fmt.Sprintf("http://steamcommunity.com/tradeoffer/%d/accept", id), netutil.ToUrlValues(map[string]string{
+	resp, err := c.client.PostForm(fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/accept", id), netutil.ToUrlValues(map[string]string{
 		"sessionid":    c.sessionId,
 		"serverid":     "1",
 		"tradeofferid": strconv.FormatUint(uint64(id), 10),
@@ -136,13 +136,13 @@ func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, the
 
 	var referer string
 	if countered != nil {
-		referer = fmt.Sprintf("http://steamcommunity.com/tradeoffer/%d/", *countered)
+		referer = fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", *countered)
 		data["tradeofferid_countered"] = fmt.Sprintf("%d", *countered)
 	} else {
-		referer = fmt.Sprintf("http://steamcommunity.com/tradeoffer/new?partner=%d", other)
+		referer = fmt.Sprintf("https://steamcommunity.com/tradeoffer/new?partner=%d", other)
 	}
 
-	req := netutil.NewPostForm("http://steamcommunity.com/tradeoffer/new/send", netutil.ToUrlValues(data))
+	req := netutil.NewPostForm("https://steamcommunity.com/tradeoffer/new/send", netutil.ToUrlValues(data))
 	req.Header.Add("Referer", referer)
 
 	resp, err := c.client.Do(req)
@@ -179,7 +179,7 @@ func (c *Client) getPartialTheirInventory(other steamid.SteamId, contextId uint6
 		data["start"] = strconv.FormatUint(uint64(*start), 10)
 	}
 
-	const baseUrl = "http://steamcommunity.com/tradeoffer/new/"
+	const baseUrl = "https://steamcommunity.com/tradeoffer/new/"
 	req, err := http.NewRequest("GET", baseUrl+"partnerinventory/?"+netutil.ToUrlValues(data).Encode(), nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This cookie is required by all HTTPs routes (you can also only get it over the HTTPs authenticate route). This is required for the newer trading changes around security and session-hijack prevention. Without this all tradeoffer-related steam web calls will fail. This fixes #19, and invalidates #20.