### PR TITLE
Add support for binding to a local IP

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,21 @@ func (c *Client) ConnectEurope() *netutil.PortAddr {
 func (c *Client) ConnectTo(addr *netutil.PortAddr) {
 	c.Disconnect()
 
-	conn, err := dialTCP(addr.ToTCPAddr())
+	conn, err := dialTCP(addr.ToTCPAddr(), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	c.conn = conn
+
+	go c.readLoop()
+	go c.writeLoop()
+}
+
+// Connects to a specific server, and binds to a specified local IP
+func (c *Client) ConnectToBind(addr *netutil.PortAddr, local *net.TCPAddr) {
+	c.Disconnect()
+
+	conn, err := dialTCP(addr.ToTCPAddr(), local)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -28,8 +28,8 @@ type tcpConnection struct {
 	cipherMutex sync.RWMutex
 }
 
-func dialTCP(addr *net.TCPAddr) (*tcpConnection, error) {
-	conn, err := net.DialTCP("tcp", nil, addr)
+func dialTCP(addr, local *net.TCPAddr) (*tcpConnection, error) {
+	conn, err := net.DialTCP("tcp", local, addr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Useful for machines which have multiple bound/NAT addresses. I purposely made this non-API breaking, however it could be consolidated within `ConnectTo` for a cleaner overall interface.