### PR TITLE
Rework error handling

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -111,7 +111,9 @@ func (a *Auth) handleLogOnResponse(packet *Packet) {
 	} else if result == EResult_Fail || result == EResult_ServiceUnavailable || result == EResult_TryAnotherCM {
 		// some error on Steam's side, we'll get an EOF later
 	} else {
-		a.client.Fatalf("Login error: %v", result)
+		a.client.Emit(&LogOnFailedEvent{
+			Result: EResult(body.GetEresult()),
+		})
 	}
 }
 

--- a/auth.go
+++ b/auth.go
@@ -114,6 +114,7 @@ func (a *Auth) handleLogOnResponse(packet *Packet) {
 		a.client.Emit(&LogOnFailedEvent{
 			Result: EResult(body.GetEresult()),
 		})
+		a.client.Disconnect()
 	}
 }
 

--- a/auth_events.go
+++ b/auth_events.go
@@ -26,6 +26,10 @@ type LoggedOnEvent struct {
 	NumDisconnectsToMigrate   int32
 }
 
+type LogOnFailedEvent struct {
+	Result EResult
+}
+
 type LoginKeyEvent struct {
 	UniqueId uint32
 	LoginKey string

--- a/client.go
+++ b/client.go
@@ -245,7 +245,6 @@ func (c *Client) readLoop() {
 }
 
 func (c *Client) writeLoop() {
-	defer c.Disconnect()
 	for {
 		c.mutex.RLock()
 		conn := c.conn
@@ -262,7 +261,7 @@ func (c *Client) writeLoop() {
 		err := msg.Serialize(c.writeBuf)
 		if err != nil {
 			c.writeBuf.Reset()
-			c.Errorf("Error serializing message %v: %v", msg, err)
+			c.Fatalf("Error serializing message %v: %v", msg, err)
 			return
 		}
 
@@ -271,7 +270,7 @@ func (c *Client) writeLoop() {
 		c.writeBuf.Reset()
 
 		if err != nil {
-			c.Errorf("Error writing message %v: %v", msg, err)
+			c.Fatalf("Error writing message %v: %v", msg, err)
 			return
 		}
 	}

--- a/web.go
+++ b/web.go
@@ -64,7 +64,7 @@ func (w *Web) LogOn() {
 			}
 		}
 		if err != nil {
-			w.client.Emit(WebLogonErrorEvent(err))
+			w.client.Emit(WebLogOnErrorEvent(err))
 			return
 		}
 	}()

--- a/web.go
+++ b/web.go
@@ -64,7 +64,7 @@ func (w *Web) LogOn() {
 			}
 		}
 		if err != nil {
-			w.client.Errorf("Web: Error logging on: %v", err)
+			w.client.Emit(WebLogonErrorEvent(err))
 			return
 		}
 	}()

--- a/web_events.go
+++ b/web_events.go
@@ -2,4 +2,6 @@ package steam
 
 type WebLoggedOnEvent struct{}
 
+type WebLogOnErrorEvent error
+
 type WebSessionIdEvent struct{}


### PR DESCRIPTION
- change writeLoop emitted events from error to FatalErrorEvent
- change ConnectTo and ConnecToBind from using log.Fatal to emiting FatalErrorEvent
- add LogOnFailedEvent containing steam result for failed log on attempt
- add WebLogOnErrorEvent containing error for failed web log on 

Fixes #50, #53 