### PR TITLE
Fix panic on reconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,9 +63,8 @@ type PacketHandler interface {
 
 func NewClient() *Client {
 	client := &Client{
-		events:    make(chan interface{}, 3),
-		writeChan: make(chan IMsg, 5),
-		writeBuf:  new(bytes.Buffer),
+		events:   make(chan interface{}, 3),
+		writeBuf: new(bytes.Buffer),
 	}
 	client.Auth = &Auth{client: client}
 	client.RegisterPacketHandler(client.Auth)
@@ -170,6 +169,7 @@ func (c *Client) ConnectTo(addr *netutil.PortAddr) {
 		log.Fatal(err)
 	}
 	c.conn = conn
+	c.writeChan = make(chan IMsg, 5)
 
 	go c.readLoop()
 	go c.writeLoop()
@@ -184,6 +184,7 @@ func (c *Client) ConnectToBind(addr *netutil.PortAddr, local *net.TCPAddr) {
 		log.Fatal(err)
 	}
 	c.conn = conn
+	c.writeChan = make(chan IMsg, 5)
 
 	go c.readLoop()
 	go c.writeLoop()


### PR DESCRIPTION
After first call to Disconnect() writeChan would stay closed on
subsequent connect attempts. This fix moves make() for writeChan
from NewClient() into ConnectTo() / ConnectToBind()