### PR TITLE
Load initial server list from steam directory

### DIFF
--- a/client.go
+++ b/client.go
@@ -134,7 +134,12 @@ func (c *Client) Connected() bool {
 // You will receive a ServerListEvent after logging in which contains a new list of servers of which you
 // should choose one yourself and connect with ConnectTo since the included list may not always be up to date.
 func (c *Client) Connect() *netutil.PortAddr {
-	server := GetRandomCM()
+	var server *netutil.PortAddr
+	if steamDirectoryCache.IsInitialized() {
+		server = steamDirectoryCache.GetRandomCM()
+	} else {
+		server = GetRandomCM()
+	}
 	c.ConnectTo(server)
 	return server
 }

--- a/steam_directory.go
+++ b/steam_directory.go
@@ -11,9 +11,9 @@ import (
 	"github.com/Philipp15b/go-steam/netutil"
 )
 
-// Allows to load initial server list from Steam Directory Web API.
-// Call InitializeSteamDirectory() before Connect(), and Connect()
-// will use loaded server list instead of hardcoded one
+// Load initial server list from Steam Directory Web API.
+// Call InitializeSteamDirectory() before Connect() to use
+// steam directory server list instead of static one.
 func InitializeSteamDirectory() error {
 	return steamDirectoryCache.Initialize()
 }
@@ -26,7 +26,7 @@ type steamDirectory struct {
 	isInitialized bool
 }
 
-// Get servers list from steam directory and save them for later use
+// Get server list from steam directory and save it for later
 func (sd *steamDirectory) Initialize() error {
 	sd.Lock()
 	defer sd.Unlock()

--- a/steam_directory.go
+++ b/steam_directory.go
@@ -1,0 +1,76 @@
+package steam
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Philipp15b/go-steam/netutil"
+)
+
+// Allows to load initial server list from Steam Directory Web API.
+// Call InitializeSteamDirectory() before Connect(), and Connect()
+// will use loaded server list instead of hardcoded one
+func InitializeSteamDirectory() error {
+	return steamDirectoryCache.Initialize()
+}
+
+var steamDirectoryCache *steamDirectory = &steamDirectory{}
+
+type steamDirectory struct {
+	sync.RWMutex
+	servers       []string
+	isInitialized bool
+}
+
+// Get servers list from steam directory and save them for later use
+func (sd *steamDirectory) Initialize() error {
+	sd.Lock()
+	defer sd.Unlock()
+	client := new(http.Client)
+	resp, err := client.Get(fmt.Sprintf("https://api.steampowered.com/ISteamDirectory/GetCMList/v1/?cellId=0"))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	r := struct {
+		Response struct {
+			ServerList []string
+			Result     uint32
+			Message    string
+		}
+	}{}
+	if err = json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return err
+	}
+	if r.Response.Result != 1 {
+		return fmt.Errorf("Failed to get steam directory, result: %v, message: %v\n", r.Response.Result, r.Response.Message)
+	}
+	if len(r.Response.ServerList) == 0 {
+		return fmt.Errorf("Steam returned zero servers for steam directory request\n")
+	}
+	sd.servers = r.Response.ServerList
+	sd.isInitialized = true
+	return nil
+}
+
+func (sd *steamDirectory) GetRandomCM() *netutil.PortAddr {
+	sd.RLock()
+	defer sd.RUnlock()
+	if !sd.isInitialized {
+		panic("steam directory is not initialized")
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	addr := netutil.ParsePortAddr(sd.servers[rng.Int31n(int32(len(sd.servers)))])
+	return addr
+}
+
+func (sd *steamDirectory) IsInitialized() bool {
+	sd.RLock()
+	defer sd.RUnlock()
+	isInitialized := sd.isInitialized
+	return isInitialized
+}


### PR DESCRIPTION
This adds one public function InitializeSteamDirectory() for loading initial server list from steam directory. Use is optional. Users have to call InitializeSteamDirectory() before calling Connect().