### PR TITLE
Rework tradeoffer and economy, update inventory

### DIFF
--- a/economy/inventory/inventory.go
+++ b/economy/inventory/inventory.go
@@ -6,7 +6,6 @@ package inventory
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/Philipp15b/go-steam/economy"
 	"github.com/Philipp15b/go-steam/jsont"
 )
 
@@ -45,30 +44,32 @@ func (d *Descriptions) UnmarshalJSON(data []byte) error {
 }
 
 type Item struct {
-	Id         economy.AssetId    `json:",string"`
-	ClassId    economy.ClassId    `json:",string"`
-	InstanceId economy.InstanceId `json:",string"`
-	Amount     uint64             `json:",string"`
+	Id         uint64 `json:",string"`
+	ClassId    uint64 `json:",string"`
+	InstanceId uint64 `json:",string"`
+	Amount     uint64 `json:",string"`
 	Pos        uint32
 }
 
 type Currency struct {
-	Id         economy.AssetId `json:",string"`
-	ClassId    economy.ClassId `json:",string"`
-	IsCurrency bool            `json:"is_currency"`
+	Id         uint64 `json:",string"`
+	ClassId    uint64 `json:",string"`
+	IsCurrency bool   `json:"is_currency"`
 	Pos        uint32
 }
 
 type Description struct {
-	AppId      uint32             `json:",string"`
-	ClassId    economy.ClassId    `json:",string"`
-	InstanceId economy.InstanceId `json:",string"`
+	AppId      uint32 `json:",string"`
+	ClassId    uint64 `json:",string"`
+	InstanceId uint64 `json:",string"`
 
-	IconUrl     string `json:"icon_url"`
-	IconDragUrl string `json:"icon_drag_url"`
+	IconUrl      string `json:"icon_url"`
+	IconUrlLarge string `json:"icon_url_large"`
+	IconDragUrl  string `json:"icon_drag_url"`
 
-	Name       string
-	MarketName string `json:"market_name"`
+	Name           string
+	MarketName     string `json:"market_name"`
+	MarketHashName string `json:"market_hash_name"`
 
 	// Colors in hex, for example `B2B2B2`
 	NameColor       string `json:"name_color"`
@@ -98,7 +99,7 @@ func (d *DescriptionLines) UnmarshalJSON(data []byte) error {
 type DescriptionLine struct {
 	Value string
 	Type  *string // Is `html` for HTML descriptions
-	Label *string
+	Color *string
 }
 
 type Action struct {

--- a/economy/inventory/inventory.go
+++ b/economy/inventory/inventory.go
@@ -6,8 +6,41 @@ package inventory
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"github.com/Philipp15b/go-steam/jsont"
+	"strconv"
 )
+
+type GenericInventory map[uint32]map[uint64]*Inventory
+
+func NewGenericInventory() GenericInventory {
+	iMap := make(map[uint32]map[uint64]*Inventory)
+	return GenericInventory(iMap)
+}
+
+// Get inventory for specified AppId and ContextId
+func (i *GenericInventory) Get(appId uint32, contextId uint64) (*Inventory, error) {
+	iMap := (map[uint32]map[uint64]*Inventory)(*i)
+	iMap2, ok := iMap[appId]
+	if !ok {
+		return nil, fmt.Errorf("inventory for specified appId not found")
+	}
+	inv, ok := iMap2[contextId]
+	if !ok {
+		return nil, fmt.Errorf("inventory for specified contextId not found")
+	}
+	return inv, nil
+}
+
+func (i *GenericInventory) Add(appId uint32, contextId uint64, inv *Inventory) {
+	iMap := (map[uint32]map[uint64]*Inventory)(*i)
+	iMap2, ok := iMap[appId]
+	if !ok {
+		iMap2 = make(map[uint64]*Inventory)
+		iMap[appId] = iMap2
+	}
+	iMap2[contextId] = inv
+}
 
 type Inventory struct {
 	Items        Items        `json:"rgInventory"`
@@ -16,7 +49,20 @@ type Inventory struct {
 	AppInfo      *AppInfo     `json:"rgAppInfo"`
 }
 
+// Items key is an AssetId
 type Items map[string]*Item
+
+func (i *Items) ToMap() map[string]*Item {
+	return (map[string]*Item)(*i)
+}
+
+func (i *Items) Get(assetId uint64) (*Item, error) {
+	iMap := (map[string]*Item)(*i)
+	if item, ok := iMap[strconv.FormatUint(assetId, 10)]; ok {
+		return item, nil
+	}
+	return nil, fmt.Errorf("item not found")
+}
 
 func (i *Items) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte("[]")) {
@@ -27,6 +73,10 @@ func (i *Items) UnmarshalJSON(data []byte) error {
 
 type Currencies map[string]*Currency
 
+func (c *Currencies) ToMap() map[string]*Currency {
+	return (map[string]*Currency)(*c)
+}
+
 func (c *Currencies) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte("[]")) {
 		return nil
@@ -34,7 +84,21 @@ func (c *Currencies) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*map[string]*Currency)(c))
 }
 
+// Descriptions key format is %d_%d, first %d is ClassId, second is InstanceId
 type Descriptions map[string]*Description
+
+func (d *Descriptions) ToMap() map[string]*Description {
+	return (map[string]*Description)(*d)
+}
+
+func (d *Descriptions) Get(classId uint64, instanceId uint64) (*Description, error) {
+	dMap := (map[string]*Description)(*d)
+	descId := fmt.Sprintf("%v_%v", classId, instanceId)
+	if desc, ok := dMap[descId]; ok {
+		return desc, nil
+	}
+	return nil, fmt.Errorf("description not found")
+}
 
 func (d *Descriptions) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte("[]")) {
@@ -77,14 +141,16 @@ type Description struct {
 
 	Type string
 
-	Tradable   jsont.UintBool
-	Marketable jsont.UintBool
-	Commodity  jsont.UintBool
+	Tradable                  jsont.UintBool
+	Marketable                jsont.UintBool
+	Commodity                 jsont.UintBool
+	MarketTradableRestriction uint32 `json:"market_tradable_restriction,string"`
 
 	Descriptions DescriptionLines
 	Actions      []*Action
 	// Application-specific data, like "def_index" and "quality" for TF2
 	AppData map[string]string
+	Tags    []*Tag
 }
 
 type DescriptionLines []*DescriptionLine
@@ -112,4 +178,11 @@ type AppInfo struct {
 	Name  string
 	Icon  string
 	Link  string
+}
+
+type Tag struct {
+	InternalName string `json:internal_name`
+	Name         string
+	Category     string
+	CategoryName string `json:category_name`
 }

--- a/economy/inventory/inventory_apps.go
+++ b/economy/inventory/inventory_apps.go
@@ -1,0 +1,79 @@
+package inventory
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Philipp15b/go-steam/steamid"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+type InventoryApps map[string]*InventoryApp
+
+func (i *InventoryApps) Get(appId uint32) (*InventoryApp, error) {
+	iMap := (map[string]*InventoryApp)(*i)
+	if inventoryApp, ok := iMap[strconv.FormatUint(uint64(appId), 10)]; ok {
+		return inventoryApp, nil
+	}
+	return nil, fmt.Errorf("inventory app not found")
+}
+
+func (i *InventoryApps) ToMap() map[string]*InventoryApp {
+	return (map[string]*InventoryApp)(*i)
+}
+
+type InventoryApp struct {
+	AppId            uint32
+	Name             string
+	Icon             string
+	Link             string
+	AssetCount       uint32   `json:"asset_count"`
+	InventoryLogo    string   `json:"inventory_logo"`
+	TradePermissions string   `json:"trade_permissions"`
+	Contexts         Contexts `json:"rgContexts"`
+}
+
+type Contexts map[string]*Context
+
+func (c *Contexts) Get(contextId uint64) (*Context, error) {
+	cMap := (map[string]*Context)(*c)
+	if context, ok := cMap[strconv.FormatUint(contextId, 10)]; ok {
+		return context, nil
+	}
+	return nil, fmt.Errorf("context not found")
+}
+
+func (c *Contexts) ToMap() map[string]*Context {
+	return (map[string]*Context)(*c)
+}
+
+type Context struct {
+	ContextId  uint64 `json:"id,string"`
+	AssetCount uint32 `json:"asset_count"`
+	Name       string
+}
+
+func GetInventoryApps(client *http.Client, steamId steamid.SteamId) (InventoryApps, error) {
+	resp, err := http.Get("http://steamcommunity.com/profiles/" + steamId.ToString() + "/inventory/")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	reg := regexp.MustCompile("var g_rgAppContextData = (.*?);")
+	inventoryAppsMatches := reg.FindSubmatch(respBody)
+	if inventoryAppsMatches == nil {
+		return nil, fmt.Errorf("profile inventory not found in steam response")
+	}
+	var inventoryApps InventoryApps
+	if err = json.Unmarshal(inventoryAppsMatches[1], &inventoryApps); err != nil {
+		return nil, err
+	}
+
+	return inventoryApps, nil
+}

--- a/economy/types.go
+++ b/economy/types.go
@@ -1,9 +1,0 @@
-package economy
-
-type AssetId uint64
-
-type ClassId uint64
-
-type InstanceId uint64
-
-type ContextId uint64

--- a/tradeoffer/client.go
+++ b/tradeoffer/client.go
@@ -2,7 +2,6 @@ package tradeoffer
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/Philipp15b/go-steam/community"
 	"github.com/Philipp15b/go-steam/economy/inventory"
@@ -10,6 +9,7 @@ import (
 	"github.com/Philipp15b/go-steam/steamid"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 type APIKey string
@@ -32,91 +32,153 @@ func NewClient(key APIKey, sessionId, steamLogin, steamLoginSecure string) *Clie
 	return c
 }
 
-func (c *Client) GetOffers() (*TradeOffers, error) {
-	resp, err := c.client.Get(fmt.Sprintf(apiUrl, "GetTradeOffers", 1) + "?" + netutil.ToUrlValues(map[string]string{
-		"key":                 string(c.key),
-		"get_sent_offers":     "1",
-		"get_received_offers": "1",
+func (c *Client) GetOffer(offerId uint64) (*TradeOfferResult, error) {
+	resp, err := c.client.Get(fmt.Sprintf(apiUrl, "GetTradeOffer", 1) + "?" + netutil.ToUrlValues(map[string]string{
+		"key":          string(c.key),
+		"tradeofferid": strconv.FormatUint(offerId, 10),
+		"language":     "en_us",
 	}).Encode())
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	t := new(struct {
-		Response *TradeOffers
+		Response *TradeOfferResult
 	})
-	err = json.NewDecoder(resp.Body).Decode(t)
-	if err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(t); err != nil {
 		return nil, err
 	}
 	return t.Response, nil
 }
 
-type actionResult struct {
-	Success bool
-	Error   string
+func (c *Client) GetOffers(getSent bool, getReceived bool, getDescriptions bool, activeOnly bool, historicalOnly bool, timeHistoricalCutoff *uint32) (*TradeOffersResult, error) {
+	if !getSent && !getReceived {
+		return nil, fmt.Errorf("getSent and getReceived can't be both false\n")
+	}
+
+	params := map[string]string{
+		"key": string(c.key),
+	}
+	if getSent {
+		params["get_sent_offers"] = "1"
+	}
+	if getReceived {
+		params["get_received_offers"] = "1"
+	}
+	if getDescriptions {
+		params["get_descriptions"] = "1"
+		params["language"] = "en_us"
+	}
+	if activeOnly {
+		params["active_only"] = "1"
+	}
+	if historicalOnly {
+		params["historical_only"] = "1"
+	}
+	if timeHistoricalCutoff != nil {
+		params["time_historical_cutoff"] = strconv.FormatUint(uint64(*timeHistoricalCutoff), 10)
+	}
+	resp, err := c.client.Get(fmt.Sprintf(apiUrl, "GetTradeOffers", 1) + "?" + netutil.ToUrlValues(params).Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	t := new(struct {
+		Response *TradeOffersResult
+	})
+	if err = json.NewDecoder(resp.Body).Decode(t); err != nil {
+		return nil, err
+	}
+	return t.Response, nil
 }
 
-func (c *Client) action(method string, version uint, id TradeOfferId) error {
+func (c *Client) action(method string, version uint, offerId uint64) error {
 	resp, err := c.client.Do(netutil.NewPostForm(fmt.Sprintf(apiUrl, method, version), netutil.ToUrlValues(map[string]string{
 		"key":          string(c.key),
-		"tradeofferid": strconv.FormatUint(uint64(id), 10),
+		"tradeofferid": strconv.FormatUint(offerId, 10),
 	})))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return errors.New(method + " error: status code not 200")
+		return fmt.Errorf(method+" error: status code %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return err
+	}
+	success, ok := result["success"]
+	if !ok {
+		return newSteamErrorf(method + " error: no success field\n")
+	}
+	if success != "1" {
+		return newSteamErrorf(method+" error: success field is %v\n", success)
 	}
 	return nil
 }
 
-func (c *Client) Decline(id TradeOfferId) error {
-	return c.action("DeclineTradeOffer", 1, id)
+func (c *Client) Decline(offerId uint64) error {
+	return c.action("DeclineTradeOffer", 1, offerId)
 }
 
-func (c *Client) Cancel(id TradeOfferId) error {
-	return c.action("CancelTradeOffer", 1, id)
+func (c *Client) Cancel(offerId uint64) error {
+	return c.action("CancelTradeOffer", 1, offerId)
 }
 
-func (c *Client) Accept(id TradeOfferId) error {
-	baseurl := fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", id)
+// on success returns trade id
+func (c *Client) Accept(offerId uint64) (uint64, error) {
+	baseurl := fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", offerId)
 	req := netutil.NewPostForm(baseurl+"accept", netutil.ToUrlValues(map[string]string{
 		"sessionid":    c.sessionId,
 		"serverid":     "1",
-		"tradeofferid": strconv.FormatUint(uint64(id), 10),
+		"tradeofferid": strconv.FormatUint(offerId, 10),
 	}))
 	req.Header.Add("Referer", baseurl)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("accept error: status code %d", resp.StatusCode)
+		return 0, fmt.Errorf("accept error: status code %d", resp.StatusCode)
 	}
-	return nil
+	var result map[string]string
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return 0, err
+	}
+	if strError, ok := result["strError"]; ok {
+		return 0, newSteamErrorf("accept error: %v\n", strError)
+	}
+	tradeIdString, ok := result["tradeid"]
+	if !ok {
+		return 0, newSteamErrorf("accept error: steam does not return trade id\n")
+	}
+	tradeId, err := strconv.ParseUint(tradeIdString, 10, 64)
+	if err != nil || tradeId == 0 {
+		return 0, newSteamErrorf("accept error: steam returned %v for trade id", tradeIdString)
+	}
+	return tradeId, nil
 }
 
 type TradeItem struct {
-	AppId     uint32 `json:"appid"`
-	ContextId uint64 `json:"contextid"`
-	Amount    uint   `json:"amount"`
-	AssetId   uint64 `json:"assetid"`
-}
-
-type TradeCreateResult struct {
-	TradeOfferId uint64 `json:",string"`
+	AppId      uint32
+	ContextId  uint64
+	Amount     uint64
+	AssetId    uint64 `json:",string,omitempty"`
+	CurrencyId uint64 `json:",string,omitempty"`
 }
 
 // Sends a new trade offer to the given Steam user. You can optionally specify an access token if you've got one.
-// In addition, `countered` can be non-nil, indicating the trade offer this is a counter for.
-func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, theirItems []TradeItem, countered *TradeOfferId, message string) (*TradeCreateResult, error) {
+// In addition, `counteredOfferId` can be non-nil, indicating the trade offer this is a counter for.
+// On success returns trade offer id
+func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, theirItems []TradeItem, counteredOfferId *uint64, message string) (uint64, error) {
+	// Create new trade offer status
 	to := map[string]interface{}{
 		"newversion": true,
-		"version":    "3",
+		"version":    3,
 		"me": map[string]interface{}{
 			"assets":   myItems,
 			"currency": make([]struct{}, 0),
@@ -134,53 +196,69 @@ func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, the
 		panic(err)
 	}
 
-	params := make(map[string]string)
-	if accessToken != nil {
-		params["trade_offer_access_token"] = *accessToken
-	}
-
-	paramsJson, err := json.Marshal(params)
-	if err != nil {
-		panic(err)
-	}
-
+	// Create url parameters for request
 	data := map[string]string{
-		"sessionid":                 c.sessionId,
-		"serverid":                  "1",
-		"partner":                   fmt.Sprintf("%d", other),
-		"tradeoffermessage":         message,
-		"json_tradeoffer":           string(jto),
-		"captcha":                   "",
-		"trade_offer_create_params": string(paramsJson),
+		"sessionid":         c.sessionId,
+		"serverid":          "1",
+		"partner":           other.ToString(),
+		"tradeoffermessage": message,
+		"json_tradeoffer":   string(jto),
+		"captcha":           "",
 	}
 
 	var referer string
-	if countered != nil {
-		referer = fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", *countered)
-		data["tradeofferid_countered"] = fmt.Sprintf("%d", *countered)
+	if counteredOfferId != nil {
+		referer = fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", *counteredOfferId)
+		data["tradeofferid_countered"] = strconv.FormatUint(*counteredOfferId, 10)
 	} else {
-		referer = fmt.Sprintf("https://steamcommunity.com/tradeoffer/new?partner=%d", other)
+		// Add token for non-friend offers
+		if accessToken != nil {
+			params := map[string]string{
+				"trade_offer_access_token": *accessToken,
+			}
+			paramsJson, err := json.Marshal(params)
+			if err != nil {
+				panic(err)
+			}
+
+			data["trade_offer_create_params"] = string(paramsJson)
+
+			referer = "https://steamcommunity.com/tradeoffer/new/?partner=" + strconv.FormatUint(uint64(other.GetAccountId()), 10) + "&token=" + *accessToken
+		} else {
+
+			referer = "https://steamcommunity.com/tradeoffer/new/?partner=" + strconv.FormatUint(uint64(other.GetAccountId()), 10)
+		}
 	}
 
+	// Create request
 	req := netutil.NewPostForm("https://steamcommunity.com/tradeoffer/new/send", netutil.ToUrlValues(data))
 	req.Header.Add("Referer", referer)
 
+	// Send request
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer resp.Body.Close()
-
-	// If we failed, error out
 	if resp.StatusCode != 200 {
-		return nil, errors.New("create error: status code not 200")
+		return 0, fmt.Errorf("create error: status code %d", resp.StatusCode)
 	}
-
-	// Load the JSON result into TradeCreateResult
-	result := new(TradeCreateResult)
-	decoder := json.NewDecoder(resp.Body)
-	decoder.Decode(result)
-	return result, nil
+	var result map[string]string
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return 0, err
+	}
+	if strError, ok := result["strError"]; ok {
+		return 0, newSteamErrorf("create error: %v\n", strError)
+	}
+	offerIdString, ok := result["tradeofferid"]
+	if !ok {
+		return 0, newSteamErrorf("create error: steam does not return trade offer id\n")
+	}
+	offerId, err := strconv.ParseUint(offerIdString, 10, 64)
+	if err != nil || offerId == 0 {
+		return 0, newSteamErrorf("create error: steam returned %v for trade offer id", offerIdString)
+	}
+	return offerId, nil
 }
 
 func (c *Client) GetOwnInventory(contextId uint64, appId uint32) (*inventory.Inventory, error) {
@@ -214,4 +292,95 @@ func (c *Client) getPartialTheirInventory(other steamid.SteamId, contextId uint6
 	req.Header.Add("Referer", baseUrl+"?partner="+fmt.Sprintf("%d", other))
 
 	return inventory.DoInventoryRequest(c.client, req)
+}
+
+func (c *Client) GetOfferWithRetry(offerId uint64, retryCount int, retryWait time.Duration) (*TradeOfferResult, error) {
+	var res *TradeOfferResult
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.GetOffer(offerId)
+			return err
+		}, retryCount, retryWait)
+}
+
+func (c *Client) GetOffersWithRetry(getSent bool, getReceived bool, getDescriptions bool, activeOnly bool, historicalOnly bool, timeHistoricalCutoff *uint32, retryCount int, retryWait time.Duration) (*TradeOffersResult, error) {
+	var res *TradeOffersResult
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.GetOffers(getSent, getReceived, getDescriptions, activeOnly, historicalOnly, timeHistoricalCutoff)
+			return err
+		}, retryCount, retryWait)
+}
+
+func (c *Client) DeclineWithRetry(offerId uint64, retryCount int, retryWait time.Duration) error {
+	return withRetry(
+		func() error {
+			return c.Decline(offerId)
+		}, retryCount, retryWait)
+}
+
+func (c *Client) CancelWithRetry(offerId uint64, retryCount int, retryWait time.Duration) error {
+	return withRetry(
+		func() error {
+			return c.Cancel(offerId)
+		}, retryCount, retryWait)
+}
+
+func (c *Client) AcceptWithRetry(offerId uint64, retryCount int, retryWait time.Duration) (uint64, error) {
+	var res uint64
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.Accept(offerId)
+			return err
+		}, retryCount, retryWait)
+}
+
+func (c *Client) CreateWithRetry(other steamid.SteamId, accessToken *string, myItems, theirItems []TradeItem, counteredOfferId *uint64, message string, retryCount int, retryWait time.Duration) (uint64, error) {
+	var res uint64
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.Create(other, accessToken, myItems, theirItems, counteredOfferId, message)
+			return err
+		}, retryCount, retryWait)
+}
+
+func (c *Client) GetOwnInventoryWithRetry(contextId uint64, appId uint32, retryCount int, retryWait time.Duration) (*inventory.Inventory, error) {
+	var res *inventory.Inventory
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.GetOwnInventory(contextId, appId)
+			return err
+		}, retryCount, retryWait)
+}
+
+func (c *Client) GetTheirInventoryWithRetry(other steamid.SteamId, contextId uint64, appId uint32, retryCount int, retryWait time.Duration) (*inventory.Inventory, error) {
+	var res *inventory.Inventory
+	return res, withRetry(
+		func() (err error) {
+			res, err = c.GetTheirInventory(other, contextId, appId)
+			return err
+		}, retryCount, retryWait)
+}
+
+func withRetry(f func() error, retryCount int, retryWait time.Duration) error {
+	if retryCount <= 0 {
+		panic("retry count must be more than 0")
+	}
+	i := 0
+	for {
+		i++
+		if err := f(); err != nil {
+			// If we got steam error do not retry
+			if _, ok := err.(*SteamError); ok {
+				return err
+			}
+			if i == retryCount {
+				return err
+			}
+			time.Sleep(retryWait)
+			continue
+		}
+		break
+	}
+	return nil
 }

--- a/tradeoffer/error.go
+++ b/tradeoffer/error.go
@@ -1,0 +1,19 @@
+package tradeoffer
+
+import (
+	"fmt"
+)
+
+// SteamError can be returned by Create, Accept, Decline and Cancel methods.
+// It means we got response from steam, but it was in unknown format
+// or request was declined.
+type SteamError struct {
+	msg string
+}
+
+func (e *SteamError) Error() string {
+	return e.msg
+}
+func newSteamErrorf(format string, a ...interface{}) *SteamError {
+	return &SteamError{fmt.Sprintf(format, a...)}
+}

--- a/tradeoffer/escrow.go
+++ b/tradeoffer/escrow.go
@@ -1,0 +1,40 @@
+package tradeoffer
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type EscrowDuration struct {
+	DaysMyEscrow    uint32
+	DaysTheirEscrow uint32
+}
+
+func parseEscrowDuration(data []byte) (*EscrowDuration, error) {
+	// TODO: why we are using case insensitive matching?
+	myRegex := regexp.MustCompile("(?i)g_daysMyEscrow[\\s=]+(\\d+);")
+	theirRegex := regexp.MustCompile("(?i)g_daysTheirEscrow[\\s=]+(\\d+);")
+
+	myM := myRegex.FindSubmatch(data)
+	theirM := theirRegex.FindSubmatch(data)
+
+	if myM == nil || theirM == nil {
+		return nil, errors.New("regexp does not match")
+	}
+
+	myEscrow, err := strconv.ParseUint(string(myM[1]), 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse my duration into uint: %v", err)
+	}
+	theirEscrow, err := strconv.ParseUint(string(theirM[1]), 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse their duration into uint: %v", err)
+	}
+
+	return &EscrowDuration{
+		DaysMyEscrow:    uint32(myEscrow),
+		DaysTheirEscrow: uint32(theirEscrow),
+	}, nil
+}

--- a/tradeoffer/receipt.go
+++ b/tradeoffer/receipt.go
@@ -1,0 +1,35 @@
+package tradeoffer
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Philipp15b/go-steam/economy/inventory"
+	"regexp"
+)
+
+type TradeReceiptItem struct {
+	AssetId   uint64 `json:"id,string"`
+	AppId     uint32
+	ContextId uint64
+	Owner     uint64 `json:",string"`
+	Pos       uint32
+	inventory.Description
+}
+
+func parseTradeReceipt(data []byte) ([]*TradeReceiptItem, error) {
+	reg := regexp.MustCompile("oItem =\\s+(.+?});")
+	itemMatches := reg.FindAllSubmatch(data, -1)
+	if itemMatches == nil {
+		return nil, fmt.Errorf("items not found\n")
+	}
+	items := make([]*TradeReceiptItem, 0, len(itemMatches))
+	for _, m := range itemMatches {
+		item := new(TradeReceiptItem)
+		err := json.Unmarshal(m[1], &item)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}

--- a/tradeoffer/tradeoffer.go
+++ b/tradeoffer/tradeoffer.go
@@ -6,6 +6,7 @@ See: https://developer.valvesoftware.com/wiki/Steam_Web_API/IEconService
 package tradeoffer
 
 import (
+	"encoding/json"
 	"github.com/Philipp15b/go-steam/economy/inventory"
 	"github.com/Philipp15b/go-steam/steamid"
 )
@@ -13,20 +14,29 @@ import (
 type TradeOfferState uint
 
 const (
-	TradeOfferState_Invalid       TradeOfferState = 1  // Invalid
-	TradeOfferState_Active                        = 2  // This trade offer has been sent, neither party has acted on it yet.
-	TradeOfferState_Accepted                      = 3  // The trade offer was accepted by the recipient and items were exchanged.
-	TradeOfferState_Countered                     = 4  // The recipient made a counter offer
-	TradeOfferState_Expired                       = 5  // The trade offer was not accepted before the expiration date
-	TradeOfferState_Canceled                      = 6  // The sender cancelled the offer
-	TradeOfferState_Declined                      = 7  // The recipient declined the offer
-	TradeOfferState_InvalidItems                  = 8  // Some of the items in the offer are no longer available (indicated by the missing flag in the output)
-	TradeOfferState_EmailPending                  = 9  // The offer hasn't been sent yet and is awaiting email confirmation. The offer is only visible to the sender.
-	TradeOfferState_EmailCanceled                 = 10 // Either party canceled the offer via email. The offer is visible to both parties, even if the sender canceled it before it was sent.
+	TradeOfferState_Invalid                  TradeOfferState = 1  // Invalid
+	TradeOfferState_Active                                   = 2  // This trade offer has been sent, neither party has acted on it yet.
+	TradeOfferState_Accepted                                 = 3  // The trade offer was accepted by the recipient and items were exchanged.
+	TradeOfferState_Countered                                = 4  // The recipient made a counter offer
+	TradeOfferState_Expired                                  = 5  // The trade offer was not accepted before the expiration date
+	TradeOfferState_Canceled                                 = 6  // The sender cancelled the offer
+	TradeOfferState_Declined                                 = 7  // The recipient declined the offer
+	TradeOfferState_InvalidItems                             = 8  // Some of the items in the offer are no longer available (indicated by the missing flag in the output)
+	TradeOfferState_CreatedNeedsConfirmation                 = 9  // The offer hasn't been sent yet and is awaiting email/mobile confirmation. The offer is only visible to the sender.
+	TradeOfferState_CanceledBySecondFactor                   = 10 // Either party canceled the offer via email/mobile. The offer is visible to both parties, even if the sender canceled it before it was sent.
+	TradeOfferState_InEscrow                                 = 11 // The trade has been placed on hold. The items involved in the trade have all been removed from both parties' inventories and will be automatically delivered in the future.
+)
+
+type TradeOfferConfirmationMethod uint
+
+const (
+	TradeOfferConfirmationMethod_Invalid   TradeOfferConfirmationMethod = 0
+	TradeOfferConfirmationMethod_Email                                  = 1
+	TradeOfferConfirmationMethod_MobileApp                              = 2
 )
 
 type Asset struct {
-	AppId      uint64 `json:",string"`
+	AppId      uint32 `json:",string"`
 	ContextId  uint64 `json:",string"`
 	AssetId    uint64 `json:",string"`
 	CurrencyId uint64 `json:",string"`
@@ -37,25 +47,72 @@ type Asset struct {
 }
 
 type TradeOffer struct {
-	TradeOfferId   uint64          `json:",string"`
-	OtherAccountId steamid.SteamId `json:"accountid_other"`
-	Message        string
-	ExpirationTime uint32          `json:"expiraton_time"`
-	State          TradeOfferState `json:"trade_offer_state"`
-	ToGive         []*Asset        `json:"items_to_give"`
-	ToReceive      []*Asset        `json:"items_to_receive"`
-	IsOurs         bool            `json:"is_our_offer"`
-	TimeCreated    uint32          `json:"time_created"`
-	TimeUpdated    uint32          `json:"time_updated"`
+	TradeOfferId       uint64                       `json:",string"`
+	TradeId            uint64                       `json:",string"`
+	OtherAccountId     uint32                       `json:"accountid_other"`
+	OtherSteamId       steamid.SteamId              `json:"-"`
+	Message            string                       `json:"message"`
+	ExpirationTime     uint32                       `json:"expiraton_time"`
+	State              TradeOfferState              `json:"trade_offer_state"`
+	ToGive             []*Asset                     `json:"items_to_give"`
+	ToReceive          []*Asset                     `json:"items_to_receive"`
+	IsOurOffer         bool                         `json:"is_our_offer"`
+	TimeCreated        uint32                       `json:"time_created"`
+	TimeUpdated        uint32                       `json:"time_updated"`
+	EscrowEndDate      uint32                       `json:"escrow_end_date"`
+	ConfirmationMethod TradeOfferConfirmationMethod `json:"confirmation_method"`
+}
+
+func (t *TradeOffer) UnmarshalJSON(data []byte) error {
+	type Alias TradeOffer
+	aux := struct {
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if t.OtherAccountId == 0 {
+		t.OtherSteamId = steamid.SteamId(0)
+		return nil
+	}
+	t.OtherSteamId = steamid.SteamId(uint64(t.OtherAccountId) + 76561197960265728)
+	return nil
 }
 
 type TradeOffersResult struct {
 	Sent         []*TradeOffer `json:"trade_offers_sent"`
 	Received     []*TradeOffer `json:"trade_offers_received"`
-	Descriptions inventory.Descriptions
+	Descriptions []*Description
 }
 
 type TradeOfferResult struct {
 	Offer        *TradeOffer
-	Descriptions inventory.Descriptions
+	Descriptions []*Description
+}
+type Description struct {
+	AppId      uint32 `json:",string"`
+	ClassId    uint64 `json:",string"`
+	InstanceId uint64 `json:",string"`
+
+	IconUrl      string `json:"icon_url"`
+	IconUrlLarge string `json:"icon_url_large"`
+
+	Name           string
+	MarketName     string `json:"market_name"`
+	MarketHashName string `json:"market_hash_name"`
+
+	// Colors in hex, for example `B2B2B2`
+	NameColor       string `json:"name_color"`
+	BackgroundColor string `json:"background_color"`
+
+	Type string
+
+	Tradable                  bool
+	Commodity                 bool
+	MarketTradableRestriction uint32 `json:"market_tradable_restriction"`
+
+	Descriptions inventory.DescriptionLines
+	Actions      []*inventory.Action
 }

--- a/tradeoffer/tradeoffer.go
+++ b/tradeoffer/tradeoffer.go
@@ -6,7 +6,6 @@ See: https://developer.valvesoftware.com/wiki/Steam_Web_API/IEconService
 package tradeoffer
 
 import (
-	"github.com/Philipp15b/go-steam/economy"
 	"github.com/Philipp15b/go-steam/economy/inventory"
 	"github.com/Philipp15b/go-steam/steamid"
 )
@@ -14,31 +13,31 @@ import (
 type TradeOfferState uint
 
 const (
-	TradeOfferState_Invalid      TradeOfferState = 1 // Invalid
-	TradeOfferState_Active                       = 2 // This trade offer has been sent, neither party has acted on it yet.
-	TradeOfferState_Accepted                     = 3 // The trade offer was accepted by the recipient and items were exchanged.
-	TradeOfferState_Countered                    = 4 // The recipient made a counter offer
-	TradeOfferState_Expired                      = 5 // The trade offer was not accepted before the expiration date
-	TradeOfferState_Canceled                     = 6 // The sender cancelled the offer
-	TradeOfferState_Declined                     = 7 // The recipient declined the offer
-	TradeOfferState_InvalidItems                 = 8 // Some of the items in the offer are no longer available (indicated by the missing flag in the output)
+	TradeOfferState_Invalid       TradeOfferState = 1  // Invalid
+	TradeOfferState_Active                        = 2  // This trade offer has been sent, neither party has acted on it yet.
+	TradeOfferState_Accepted                      = 3  // The trade offer was accepted by the recipient and items were exchanged.
+	TradeOfferState_Countered                     = 4  // The recipient made a counter offer
+	TradeOfferState_Expired                       = 5  // The trade offer was not accepted before the expiration date
+	TradeOfferState_Canceled                      = 6  // The sender cancelled the offer
+	TradeOfferState_Declined                      = 7  // The recipient declined the offer
+	TradeOfferState_InvalidItems                  = 8  // Some of the items in the offer are no longer available (indicated by the missing flag in the output)
+	TradeOfferState_EmailPending                  = 9  // The offer hasn't been sent yet and is awaiting email confirmation. The offer is only visible to the sender.
+	TradeOfferState_EmailCanceled                 = 10 // Either party canceled the offer via email. The offer is visible to both parties, even if the sender canceled it before it was sent.
 )
 
 type Asset struct {
-	AppId      uint64             `json:",string"`
-	ContextId  economy.ContextId  `json:",string"`
-	AssetId    economy.AssetId    `json:",string"`
-	CurrencyId uint64             `json:",string"`
-	ClassId    economy.ClassId    `json:",string"`
-	InstanceId economy.InstanceId `json:",string"`
-	Amount     uint64             `json:",string"`
+	AppId      uint64 `json:",string"`
+	ContextId  uint64 `json:",string"`
+	AssetId    uint64 `json:",string"`
+	CurrencyId uint64 `json:",string"`
+	ClassId    uint64 `json:",string"`
+	InstanceId uint64 `json:",string"`
+	Amount     uint64 `json:",string"`
 	Missing    bool
 }
 
-type TradeOfferId uint64
-
 type TradeOffer struct {
-	TradeOfferId   TradeOfferId    `json:",string"`
+	TradeOfferId   uint64          `json:",string"`
 	OtherAccountId steamid.SteamId `json:"accountid_other"`
 	Message        string
 	ExpirationTime uint32          `json:"expiraton_time"`
@@ -50,8 +49,13 @@ type TradeOffer struct {
 	TimeUpdated    uint32          `json:"time_updated"`
 }
 
-type TradeOffers struct {
+type TradeOffersResult struct {
 	Sent         []*TradeOffer `json:"trade_offers_sent"`
 	Received     []*TradeOffer `json:"trade_offers_received"`
+	Descriptions inventory.Descriptions
+}
+
+type TradeOfferResult struct {
+	Offer        *TradeOffer
 	Descriptions inventory.Descriptions
 }


### PR DESCRIPTION
- Rework error handling, add SteamError type
- Add GetOffer()
- Change GetOffers() to accept params
- Add retry methods to tradeoffer
- Remove economy types, change to use uint64
- Update economy/inventory structs
- Update tradeoffer structs
- Small fixes

This is not production ready. Interested in comments and feature requests. 

Not sure about retry logic, maybe it would be better to implement it more generically by changing all methods to return only error and allowing to use WithReconnect(Method(param), retryCount, retryWait).