### PR TITLE
Fixes for tradeoffer

### DIFF
--- a/tradeoffer/client.go
+++ b/tradeoffer/client.go
@@ -146,13 +146,13 @@ func (c *Client) Accept(offerId uint64) error {
 	}
 	defer resp.Body.Close()
 	t := new(struct {
-		strError string `json:"strError"`
+		StrError string `json:"strError"`
 	})
 	if err = json.NewDecoder(resp.Body).Decode(t); err != nil {
 		return err
 	}
-	if t.strError != "" {
-		return newSteamErrorf("accept error: %v\n", t.strError)
+	if t.StrError != "" {
+		return newSteamErrorf("accept error: %v\n", t.StrError)
 	}
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("accept error: status code %d", resp.StatusCode)
@@ -237,7 +237,7 @@ func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, the
 	}
 	defer resp.Body.Close()
 	t := new(struct {
-		strError     string `json:"strError"`
+		StrError     string `json:"strError"`
 		TradeOfferId uint64 `json:"tradeofferid,string"`
 	})
 	if err = json.NewDecoder(resp.Body).Decode(t); err != nil {
@@ -250,8 +250,8 @@ func (c *Client) Create(other steamid.SteamId, accessToken *string, myItems, the
 	// 25	can't send more offers until some is accepted/cancelled...
 	// 26	object is not in our inventory
 	// error code names are in internal/steamlang/enums.go EResult_name
-	if t.strError != "" {
-		return 0, newSteamErrorf("create error: %v\n", t.strError)
+	if t.StrError != "" {
+		return 0, newSteamErrorf("create error: %v\n", t.StrError)
 	}
 	if resp.StatusCode != 200 {
 		return 0, fmt.Errorf("create error: status code %d", resp.StatusCode)

--- a/tradeoffer/client.go
+++ b/tradeoffer/client.go
@@ -128,8 +128,10 @@ func (c *Client) Cancel(offerId uint64) error {
 	return c.action("CancelTradeOffer", 1, offerId)
 }
 
-// on success returns trade id
-func (c *Client) Accept(offerId uint64) (uint64, error) {
+// Accept received trade offer
+// It is best to confirm that offer was actually accepted
+// by calling GetOffer after Accept and checking offer state
+func (c *Client) Accept(offerId uint64) error {
 	baseurl := fmt.Sprintf("https://steamcommunity.com/tradeoffer/%d/", offerId)
 	req := netutil.NewPostForm(baseurl+"accept", netutil.ToUrlValues(map[string]string{
 		"sessionid":    c.sessionId,
@@ -140,28 +142,20 @@ func (c *Client) Accept(offerId uint64) (uint64, error) {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer resp.Body.Close()
 	result := make(map[string]string)
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, err
+		return err
 	}
 	if strError, ok := result["strError"]; ok {
-		return 0, newSteamErrorf("accept error: %v\n", strError)
+		return newSteamErrorf("accept error: %v\n", strError)
 	}
 	if resp.StatusCode != 200 {
-		return 0, fmt.Errorf("accept error: status code %d", resp.StatusCode)
+		return fmt.Errorf("accept error: status code %d", resp.StatusCode)
 	}
-	tradeIdString, ok := result["tradeid"]
-	if !ok {
-		return 0, newSteamErrorf("accept error: steam does not return trade id\n")
-	}
-	tradeId, err := strconv.ParseUint(tradeIdString, 10, 64)
-	if err != nil || tradeId == 0 {
-		return 0, newSteamErrorf("accept error: steam returned %v for trade id", tradeIdString)
-	}
-	return tradeId, nil
+	return nil
 }
 
 type TradeItem struct {
@@ -391,12 +385,10 @@ func (c *Client) CancelWithRetry(offerId uint64, retryCount int, retryDelay time
 		}, retryCount, retryDelay)
 }
 
-func (c *Client) AcceptWithRetry(offerId uint64, retryCount int, retryDelay time.Duration) (uint64, error) {
-	var res uint64
-	return res, withRetry(
-		func() (err error) {
-			res, err = c.Accept(offerId)
-			return err
+func (c *Client) AcceptWithRetry(offerId uint64, retryCount int, retryDelay time.Duration) error {
+	return withRetry(
+		func() error {
+			return c.Accept(offerId)
 		}, retryCount, retryDelay)
 }
 

--- a/tradeoffer/escrow.go
+++ b/tradeoffer/escrow.go
@@ -21,7 +21,14 @@ func parseEscrowDuration(data []byte) (*EscrowDuration, error) {
 	theirM := theirRegex.FindSubmatch(data)
 
 	if myM == nil || theirM == nil {
-		return nil, errors.New("regexp does not match")
+		// check if access token is valid
+		notFriendsRegex := regexp.MustCompile(">You are not friends with this user<")
+		notFriendsM := notFriendsRegex.FindSubmatch(data)
+		if notFriendsM == nil {
+			return nil, errors.New("regexp does not match")
+		} else {
+			return nil, errors.New("you are not friends with this user")
+		}
 	}
 
 	myEscrow, err := strconv.ParseUint(string(myM[1]), 10, 32)

--- a/tradeoffer/tradeoffer.go
+++ b/tradeoffer/tradeoffer.go
@@ -92,9 +92,9 @@ type TradeOfferResult struct {
 	Descriptions []*Description
 }
 type Description struct {
-	AppId      uint32 `json:",string"`
-	ClassId    uint64 `json:",string"`
-	InstanceId uint64 `json:",string"`
+	AppId      uint32 `json:"appid"`
+	ClassId    uint64 `json:"classid,string"`
+	InstanceId uint64 `json:"instanceid,string"`
 
 	IconUrl      string `json:"icon_url"`
 	IconUrlLarge string `json:"icon_url_large"`
@@ -109,10 +109,10 @@ type Description struct {
 
 	Type string
 
-	Tradable                  bool
-	Commodity                 bool
+	Tradable                  bool   `json:"tradable"`
+	Commodity                 bool   `json:"commodity"`
 	MarketTradableRestriction uint32 `json:"market_tradable_restriction"`
 
-	Descriptions inventory.DescriptionLines
-	Actions      []*inventory.Action
+	Descriptions inventory.DescriptionLines `json:"descriptions"`
+	Actions      []*inventory.Action        `json:"actions"`
 }


### PR DESCRIPTION
- Fix: change AppId in tradeoffer description struct to non-string
- Fix: correct handling of Create/Accept responses
- Remove tradeid from Accept return because Steam now returns tradeid=null when 2FA is enabled
- Add "not friends..." error to parseEscrowDuration

I don't think there any major bugs left after these fixes.