### PR TITLE
Fixed gsbot authentication not working when steamguard is enabled.

### DIFF
--- a/gsbot/gsbot.go
+++ b/gsbot/gsbot.go
@@ -62,9 +62,10 @@ func NewAuth(bot *GsBot, details *LogOnDetails, sentryPath string) *Auth {
 }
 
 type LogOnDetails struct {
-	Username string
-	Password string
-	AuthCode string
+	Username      string
+	Password      string
+	AuthCode      string
+	TwoFactorCode string
 }
 
 // This is called automatically after every ConnectedEvent, but must be called once again manually
@@ -80,7 +81,7 @@ func (a *Auth) LogOn(details *LogOnDetails) {
 		Password:       details.Password,
 		SentryFileHash: sentry,
 		AuthCode:       details.AuthCode,
-		TwoFactorCode:  details.AuthCode,
+		TwoFactorCode:  details.TwoFactorCode,
 	})
 }
 

--- a/gsbot/gsbot.go
+++ b/gsbot/gsbot.go
@@ -80,6 +80,7 @@ func (a *Auth) LogOn(details *LogOnDetails) {
 		Password:       details.Password,
 		SentryFileHash: sentry,
 		AuthCode:       details.AuthCode,
+		TwoFactorCode:  details.AuthCode,
 	})
 }
 


### PR DESCRIPTION
Fixes gsbot authentication not working when steam mobile authentication is enabled. It might be worth making AuthCode and TwoFactorCode one value internally as I believe they are the same format and you only ever have one that's required by steam.