### PR TITLE
Made EmailDomain Accessable Before Successful Login

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -116,7 +116,8 @@ func (a *Auth) handleLogOnResponse(packet *Packet) {
 		// some error on Steam's side, we'll get an EOF later
 	} else {
 		a.client.Emit(&LogOnFailedEvent{
-			Result: EResult(body.GetEresult()),
+			Result:      EResult(body.GetEresult()),
+			EmailDomain: body.GetEmailDomain(),
 		})
 		a.client.Disconnect()
 	}

--- a/auth.go
+++ b/auth.go
@@ -11,8 +11,6 @@ import (
 	"time"
 )
 
-// test
-
 type Auth struct {
 	client  *Client
 	details *LogOnDetails

--- a/auth.go
+++ b/auth.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+// test
+
 type Auth struct {
 	client  *Client
 	details *LogOnDetails

--- a/auth_events.go
+++ b/auth_events.go
@@ -27,7 +27,8 @@ type LoggedOnEvent struct {
 }
 
 type LogOnFailedEvent struct {
-	Result EResult
+	Result      EResult
+	EmailDomain string
 }
 
 type LoginKeyEvent struct {

--- a/client.go
+++ b/client.go
@@ -157,6 +157,7 @@ func (c *Client) ConnectToBind(addr *netutil.PortAddr, local *net.TCPAddr) {
 	conn, err := dialTCP(local, addr.ToTCPAddr())
 	if err != nil {
 		c.Fatalf("Connect failed: %v", err)
+		c.Connect()
 		return
 	}
 	c.conn = conn


### PR DESCRIPTION
If you wanted to retrieve the Steam client's email domain (gmail.com), you had to sucessfully login to Steam and access it with the **LoggedOnEvent**. Now you will be able to access the client's email domain from a **LogOnFailedEvent**.
With the SteamKit2, you are able to access the EmailDomain before a successful logon. This is so you can prompt the user to check their email at gmail.com (or their own email domain).