### PR TITLE
Add Rich Presence to PersonaStateEvent

### DIFF
--- a/social.go
+++ b/social.go
@@ -365,6 +365,7 @@ func (s *Social) handlePersonaState(packet *protocol.Packet) {
 			ClanTag:                friend.GetClanTag(),
 			OnlineSessionInstances: friend.GetOnlineSessionInstances(),
 			PersonaSetByUser:       friend.GetPersonaSetByUser(),
+			RichPresence:           friend.GetRichPresence(),
 		})
 	}
 }

--- a/social_events.go
+++ b/social_events.go
@@ -3,6 +3,7 @@ package steam
 import (
 	"time"
 
+	"github.com/Philipp15b/go-steam/v2/protocol/protobuf"
 	"github.com/Philipp15b/go-steam/v2/protocol/steamlang"
 	"github.com/Philipp15b/go-steam/v2/steamid"
 )
@@ -49,6 +50,7 @@ type PersonaStateEvent struct {
 	ClanTag                string
 	OnlineSessionInstances uint32
 	PersonaSetByUser       bool
+	RichPresence           []*protobuf.CMsgClientPersonaState_Friend_KV
 }
 
 // Fired when a clan's state has been changed


### PR DESCRIPTION
This enables Rich Presence for PersonaStateEvent. Tested and got this example output when receiving a PersonaStateEvent:
> ```2021/12/05 16:04:13 [key:"status" value:"#DOTA_RP_INIT"  key:"steam_display" value:"#DOTA_RP_INIT"  key:"num_params" value:"0"  key:"BattleCup" value:"win_date: 1638666000 valid_until: 1639357200 skill_level: 6 tournament_id: 3398630 division_id: 6 team_id: 8620259 streak: 1 trophy_id: 67"  key:"WatchableGameID" value:"0"  key:"steam_player_group" value:"27490444881435970"  key:"steam_player_group_size" value:"4"  key:"party" value:"party_id: 27490444881435970 party_state: UI open: false members { steam_id: 76561198026985442 } members { steam_id: 76561198010457614 } members { steam_id: 76561198110115366 } members { steam_id: 76561198081771288 }"  key:"lobby" value:"lobby_id: 27490444942438661 lobby_state: UI password: true game_mode: DOTA_GAMEMODE_AP member_count: 1 max_member_count: 10 name: \"fff\" lobby_type: 1" ]```