### PR TITLE
fix GetFullInventory fails to load huge inventories

### DIFF
--- a/economy/inventory/partial.go
+++ b/economy/inventory/partial.go
@@ -52,7 +52,7 @@ func GetFullInventory(getFirst func() (*PartialInventory, error), getNext func(s
 	result := &first.Inventory
 	var next *PartialInventory
 	for latest := first; latest.More; latest = next {
-		next, err := getNext(uint(latest.MoreStart))
+		next, err = getNext(uint(latest.MoreStart))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
There were 2 variables _next_. One is local to the loop and another in the outer scope. On every iteration, starting from the second, _latest_ would become equal to the outer _next_ (which was always nil) and fail immediately.

